### PR TITLE
Changed import of Screen

### DIFF
--- a/venv_clean/core/ui/venvview.py
+++ b/venv_clean/core/ui/venvview.py
@@ -1,5 +1,6 @@
 from asciimatics.widgets import Frame, Layout, Button, CheckBox, Label, \
-    Divider, Screen, TextBox, Text
+    Divider, TextBox, Text
+from asciimatics.screen import Screen
 from asciimatics.exceptions import StopApplication
 from venv_clean.core.utils import find_virtualenvs, delete_folder
 


### PR DESCRIPTION
With the latest version, I get this error message:

`ImportError: cannot import name 'Screen' from 'asciimatics.widgets' `

Apparently, `Screen` has moved since `asciimatics v1.10.0`.

This fixes it.